### PR TITLE
Benevolent king fix

### DIFF
--- a/ChessGame.php
+++ b/ChessGame.php
@@ -2390,13 +2390,15 @@ class ChessGame
                     return 'O-O-O';
                 }
             }
-        } else {
+        }
+        // not an available castling move; continue checking as a normal move even for kings
+
           $moves = $this->getPossibleMoves($piece['piece'], $from, $piece['color']);    //KK start: optimize: no need to get all possible moves
           if (!in_array($to, $moves)) {
               return $this->raiseError(self::GAMES_CHESS_ERROR_CANT_MOVE_THAT_WAY,
                   array('from' => $from, 'to' => $to));
           }  //KK end
-        }
+
         $others = array();
         if ($piece['piece'] != 'K' && $piece['piece'] != 'P') {
             $others = $this->_getAllPieceSquares($piece['piece'],


### PR DESCRIPTION
New, simpler attempt at the problem outlined in PRs #14 and #15 

The old code never tested kings for valid moves, and assumed that all non-adjacent square moves were castling. Castling was then validated later. This left open all illegal but adjacent moves as possible, such as the [test case game](http://www.chess.com/echess/game?id=81142026) which permitted a player's king to take his own queen.

This change tries to adhere to the original intent, but force kings to only move in permitted castling or other valid moves. Permitted castling rules take chess 960 rules into account, and allow for the previous bug's "feature" of the king being able to move any number of squares left or right to trigger the castling notation. Castling is then validated later in the _parseMove and _validMove calls.

This fix is somewhat urgent; the app that relies on it has a launch date of Monday, Dec 23.

@jseverson Does this raise any warning signs to you?
@lackovic10 Does this appear to fix the problem you researched?
@marcosdsanchez Give this a sanity-check once-over! :)
