### PR TITLE
[RFC] Provide failing test case for king moves

### DIFF
--- a/tests/ChessGameTest.php
+++ b/tests/ChessGameTest.php
@@ -1,37 +1,81 @@
 <?php
-/**
- * Created by Vadzim Lukiashka.
- * User: vadziml
- * Date: 1/9/13
- * Time: 12:10 AM
- */
+use Chess\Game\ChessGame;
+
 error_reporting(E_ALL & ~E_STRICT & ~E_NOTICE);
-require_once 'library/ChessGame.php';
+require_once __DIR__. '/../ChessGame.php';
+require_once 'PEAR.php';
 
 class ChessGameTest extends PHPUnit_Framework_TestCase
 {
+    private $game;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->game = new ChessGame();
+    }
+
     /**
      * @dataProvider dataProvider
      */
     public function testValidMove($fen, $moves)
     {
-        $objChessGame = new ChessGame();
-        $objChessGame->resetGame($fen);
+        $this->game->resetGame($fen);
 
 //        Should not be any exception here
         foreach ($moves as $objMoveData) {
             if ($objMoveData['white']) {
                 $strCleanMove = $this->cleanSANMove($objMoveData['white']);
-                $objChessGame->moveSAN($strCleanMove);
+                $this->game->moveSAN($strCleanMove);
             }
 
             if ($objMoveData['black']) {
                 $strCleanMove = $this->cleanSANMove($objMoveData['black']);
-                $objChessGame->moveSAN($strCleanMove);
+                $this->game->moveSAN($strCleanMove);
             }
         }
     }
 
+    public function testKingValidMovesWithMoveSAN()
+    {
+        $this->game->resetGame();
+        $this->game->moveSAN('e4');
+        $this->game->moveSAN('e5');
+        $this->game->moveSAN('d4');
+        $this->game->moveSAN('exd4');
+        $this->game->moveSAN('Qxd4');
+        $this->game->moveSAN('Nc6');
+        $this->game->moveSAN('Qd1');
+        $this->game->moveSAN('Bd6');
+        $this->game->moveSAN('a3');
+        $this->game->moveSAN('Nf6');
+        $this->game->moveSAN('Nc3');
+        $this->game->moveSAN('Nxe4');
+        $this->game->moveSAN('Qe7');
+        $this->game->moveSAN('Qe2');
+        $this->assertTrue($this->game->isError($this->game->moveSAN('Kxe7')));
+    }
+
+    public function testKingValidMovesMakingMoves()
+    {
+        $this->game->resetGame();
+        $this->game->moveSquare('e2', 'e4');
+        $this->game->moveSquare('e7', 'e5');
+        $this->game->moveSquare('d2', 'd4');
+        $this->game->moveSquare('e5', 'd4');
+        $this->game->moveSquare('d1', 'd4');
+        $this->game->moveSquare('b8', 'c6');
+        $this->game->moveSquare('d4', 'd1');
+        $this->game->moveSquare('f8', 'd6');
+        $this->game->moveSquare('a2', 'a3');
+        $this->game->moveSquare('g8', 'f6');
+        $this->game->moveSquare('b1', 'c3');
+        $this->game->moveSquare('f6', 'e4');
+        $this->game->moveSquare('c3', 'e4');
+        $this->game->moveSquare('d8', 'e7');
+        $this->game->moveSquare('d1', 'e2');
+        $this->assertTrue($this->game->isError($this->game->moveSquare('e8', 'e7')));
+    }
 //    TODO: add more combinations if needed
     public function dataProvider()
     {


### PR DESCRIPTION
Failing test case for the bug that @BiviaBen explains in #16 

The following test case fails in `master` and passes in the branch `BPC/benevolent-king-fix`

Ignore travis-ci for master based PRs. Use `phpunit tests/ChessGameTest` to test. 

Notice that testKingValidMovesMakingMoves is the test that fails. TestKingValidMovesWithMoveSAN passes. 

//cc @jseverson @lackovic10 
