### PR TITLE
Bugfix: Move list should not be modified after checking if the game is in stalemate

### DIFF
--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -955,4 +955,12 @@ class ChessGameTest extends TestExtensions
         $this->game->moveSAN('e4');
         $this->assertEquals('B', $this->game->toMove());
     }
+
+    public function testMovesShouldNotBeChangedAfterCheckingIfGameInStalemate()
+    {
+        $this->game->resetGame();
+        $this->game->moveSAN('h3');
+        $this->assertFalse($this->game->inStaleMate());
+        $this->assertEquals(array(1 => array('h3')), $this->game->getMoveList());
+    }
 }

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -1277,15 +1277,18 @@ class ChessGame
      */
     public function inStaleMate($color = null)
     {
+        $this->startTransaction();
         if (is_null($color)) {
             $color = $this->_move;
         }
         $color = strtoupper($color);
         if (!in_array($color, array('W', 'B'))) {
+            $this->rollbackTransaction();
             return $this->raiseError(self::GAMES_CHESS_ERROR_INVALID_COLOR,
                 array('color' => $color));
         }
         if ($this->inCheck($color)) {
+            $this->rollbackTransaction();
             return false;
         }
         $moves = $this->getPossibleChecks($color);
@@ -1293,15 +1296,16 @@ class ChessGame
             if (count($canMove)) {
                 $a = $this->getPiece($name);
                 foreach ($canMove as $move) {
-                    $this->startTransaction();
                     $this->_move = $color;
 
                     if (!$this->isError($this->moveSquare($a, $move))) {
+                        $this->rollbackTransaction();
                         return false;
                     }
                 }
             }
         }
+        $this->rollbackTransaction();
 
         return true;
     }


### PR DESCRIPTION
The following PR contains a test that fails because the move list is modified when checking if the game is over.

It also contains a fix for the bug. To fix the bug, I'm avoiding the modification of the internal state of the object.
