### PR TITLE
Fix moveliststring E_NOTICE error

### DIFF
--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -783,7 +783,7 @@ class ChessGameTest extends TestExtensions
 
     public function testMoveListString()
     {
-        $moves = array('Nf3', 'Nf6', 'c4', 'e6', 'Nc3', 'Bb4');
+        $moves = array('Nf3', 'Nf6', 'c4', 'e6', 'Nc3');
 
         $this->game->resetGame();
 
@@ -793,7 +793,7 @@ class ChessGameTest extends TestExtensions
 
         $moveList = $this->game->getMoveListString();
         $this->assertTrue(is_string($moveList));
-        $this->assertEquals('1.Nf3 Nf6 2.c4 e6 3.Nc3 Bb4', $moveList);
+        $this->assertEquals('1.Nf3 Nf6 2.c4 e6 3.Nc3', $moveList);
     }
 
     public function testMoveListWithChecks()

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -1181,12 +1181,12 @@ class ChessGame
                 $strMoveList .= ' ';
             }
             $strMoveList .= $key . '.';
-            if ($objMove[0]) {
+            if (isset($objMove[0])) {
                 $strMoveList .= $objMove[0];
             } else {
                 $strMoveList .= '..';
             }
-            if ($objMove[1]) {
+            if (isset($objMove[1])) {
                 $strMoveList .= ' ' . $objMove[1];
             }
             $intCount++;


### PR DESCRIPTION
The moveListString method throws an E_NOTICE error when testing a game with an odd number of moves. This PR includes a commit that shows the failure and the other commit fixes the bug.
