### PR TITLE
changing how piece keys are handled to allow any number of duplicate pieces

### DIFF
--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -21,41 +21,6 @@ class ChessGameTest extends TestExtensions
         $this->assertEquals('8/p7/8/8/8/8/8/8 w KQkq - 1 1', $this->game->renderFen());
     }
 
-    public function testAddPieceInvalidPromotedPawnForBishopKnightRook()
-    {
-        foreach (array('B', 'N', 'R') as $piece) {
-            $this->game->blankBoard();
-            $this->game->addPiece('B', 'P', 'a7');
-            $this->game->addPiece('B', 'P', 'b7');
-            $this->game->addPiece('B', 'P', 'c7');
-            $this->game->addPiece('B', 'P', 'd7');
-            $this->game->addPiece('B', 'P', 'e7');
-            $this->game->addPiece('B', 'P', 'f7');
-            $this->game->addPiece('B', 'P', 'g7');
-            $this->game->addPiece('B', 'P', 'h7');
-
-            $this->game->addPiece('B', $piece, 'a8');
-            $this->game->addPiece('B', $piece, 'h8');
-            $this->assertInstanceOf('PEAR_Error', $this->game->addPiece('B', $piece, 'a1'));
-        }
-    }
-
-    public function testAddPieceInvalidPromotedPawnForQueen()
-    {
-        $this->game->blankBoard();
-        $this->game->addPiece('B', 'P', 'a7');
-        $this->game->addPiece('B', 'P', 'b7');
-        $this->game->addPiece('B', 'P', 'c7');
-        $this->game->addPiece('B', 'P', 'd7');
-        $this->game->addPiece('B', 'P', 'e7');
-        $this->game->addPiece('B', 'P', 'f7');
-        $this->game->addPiece('B', 'P', 'g7');
-        $this->game->addPiece('B', 'P', 'h7');
-
-        $this->game->addPiece('B', 'Q', 'd8');
-        $this->assertInstanceOf('PEAR_Error', $this->game->addPiece('B', 'Q', 'a1'));
-    }
-
     public function testAddPiecePromotedPawnForBishopKnightRook()
     {
         foreach (array('B', 'N', 'R') as $piece) {
@@ -78,20 +43,6 @@ class ChessGameTest extends TestExtensions
         $this->game->blankBoard();
         $this->game->addPiece('B', 'K', 'e8');
         $this->assertInstanceOf('PEAR_Error', $this->game->addPiece('B', 'K', 'a6'));
-    }
-
-    public function testAddPieceInvalidAddingPawnWhenAllAlreadyExist()
-    {
-        $this->game->blankBoard();
-        $this->game->addPiece('B', 'P', 'a7');
-        $this->game->addPiece('B', 'P', 'b7');
-        $this->game->addPiece('B', 'P', 'c7');
-        $this->game->addPiece('B', 'P', 'd7');
-        $this->game->addPiece('B', 'P', 'e7');
-        $this->game->addPiece('B', 'P', 'f7');
-        $this->game->addPiece('B', 'P', 'g7');
-        $this->game->addPiece('B', 'P', 'h7');
-        $this->assertInstanceOf('PEAR_Error', $this->game->addPiece('B', 'P', 'a6'));
     }
 
     public function testAddPieceInvalidSquareParameterError()
@@ -990,5 +941,11 @@ class ChessGameTest extends TestExtensions
         $this->game->moveSAN('h3');
         $this->assertFalse($this->game->inStaleMate());
         $this->assertEquals(array(1 => array('h3')), $this->game->getMoveList());
+    }
+
+    public function testInitialSetupWithDuplicatedPiecesShouldBeValid()
+    {
+        $this->game->resetGame('nnnnknnn/pppppppp/8/8/8/8/PPPPPPPP/R1BQKB1R w KQ -');
+        $this->assertTrue($this->game->moveSAN('b3'));
     }
 }

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -1625,6 +1625,28 @@ class ChessGame
     }
 
     /**
+     * Finds the next available key for a given piece name
+     *
+     * Example: If piece_name is "BN" it will find the next available BN name. If there are 6
+     * black knights already, it should return "BN7"
+     *
+     * @param string $color  Color of piece (W/B)
+     * @param string $type        Piece type (P|N|K|Q|R|B)
+     *
+     * @return string $pieceName
+     */
+    private function getNextPieceName($color, $type)
+    {
+        $pieceNumber = 1;
+        $pieceString = $color . $type;
+        while (isset($this->_pieces[$pieceString . $pieceNumber]) && $this->_pieces[$pieceString . $pieceNumber]) {
+            $pieceNumber++;
+        }
+
+        return $pieceString . $pieceNumber;
+    }
+
+    /**
      * Add a piece to the chessboard
      *
      * Must be overridden in child classes
@@ -1656,71 +1678,24 @@ class ChessGame
             case 'B' :
             case 'N' :
             case 'R' :
-                $piece_name = $color . $type;
-                if (!$this->_pieces[$piece_name . '1']) {
-                    $this->_board[$square] = $piece_name . '1';
-                    $this->_pieces[$piece_name . '1'] = $square;
-                } elseif (!$this->_pieces[$piece_name . '2']) {
-                    $this->_board[$square] = $piece_name . '2';
-                    $this->_pieces[$piece_name . '2'] = $square;
-                } else {
-                    // handle promoted pawns
-                    for ($col = 1; $col <= 8; $col++) {
-                        if (!$this->_pieces[$color . 'P' . $col]) {
-                            $this->_pieces[$color . 'P' . $col] =
-                                array($square, $type);
-                            $this->_board[$square] = $color . 'P' . $col;
-                            break 2;
-                        }
-                    }
-
-                    return $this->raiseError(self::GAMES_CHESS_ERROR_MULTIPIECE,
-                        array('color' => $color, 'piece' => $type));
-
-                }
-                break;
             case 'Q' :
-                $piece_name = $color . 'Q';
-                if (!$this->_pieces[$piece_name]) {
-                    $this->_board[$square] = $piece_name;
-                    $this->_pieces[$piece_name] = $square;
-                } else {
-                    // handle promoted pawns
-                    for ($col = 1; $col <= 8; $col++) {
-                        if (!$this->_pieces[$color . 'P' . $col]) {
-                            $this->_pieces[$color . 'P' . $col] =
-                                array($square, 'Q');
-                            $this->_board[$square] = $color . 'P' . $col;
-                            break 2;
-                        }
-                    }
-
-                    return $this->raiseError(self::GAMES_CHESS_ERROR_MULTIPIECE,
-                        array('color' => $color, 'piece' => $type));
-                }
+                $piece_name = $this->getNextPieceName($color, $type);
+                $this->_board[$square] = $piece_name;
+                $this->_pieces[$piece_name] = $square;
                 break;
             case 'P' :
-                // handle regular pawns
-                for ($col = 1; $col <= 8; $col++) {
-                    if (!$this->_pieces[$color . 'P' . $col]) {
-                        $this->_pieces[$color . 'P' . $col] =
-                            array($square, 'P');
-                        $this->_board[$square] = $color . 'P' . $col;
-                        break 2;
-                    }
-                }
-
-                return $this->raiseError(self::GAMES_CHESS_ERROR_MULTIPIECE,
-                    array('color' => $color, 'piece' => $type));
+                $piece_name = $this->getNextPieceName($color, $type);
+                $this->_board[$square] = $piece_name;
+                $this->_pieces[$piece_name] = array($square, 'P');
                 break;
             case 'K' :
-                if (!$this->_pieces[$color . 'K']) {
-                    $this->_pieces[$color . 'K'] = $square;
-                    $this->_board[$square] = $color . 'K';
-                } else {
+                if ($this->_pieces[$color . 'K']) {
                     return $this->raiseError(self::GAMES_CHESS_ERROR_MULTIPIECE,
                         array('color' => $color, 'piece' => $type));
                 }
+
+                $this->_pieces[$color . 'K'] = $square;
+                $this->_board[$square] = $color . 'K';
                 break;
         }
 


### PR DESCRIPTION
After creating odds chess, we realized that this library assumes that every piece came from a standard starting position. However, in odds chess, it allows weird starting positions like the following fen:

nnnnknnn/pppppppp/8/8/8/8/PPPPPPPP/R1BQKB1R w KQ -

to handle this, i modified the piece keys to allow any number of duplicate pieces. 
