### PR TITLE
Update travis configuration and test in more php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - "5.3"
+  - "5.4"
+  - "5.5"
+  - "5.6"
+
+matrix:
+  allow_failures:
+    - php: "7.0"
+  fast_finish: true
 
 before_script:
   - curl -s http://getcomposer.org/installer | php -- --quiet


### PR DESCRIPTION
Test in php 5.6 and allow failures in php 7 for now.
