### PR TITLE
Do not mark game as over if it's a not forced draw.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,9 @@
         "php": ">=5.3.2"
     },
     "require-dev": {
-        "doctrine/common": "~2.3",
-        "symfony/property-access": "~2.2",
-        "fabpot/php-cs-fixer": "*",
-        "phpunit/phpunit": "3.7.*",
-        "jtreminio/test-extensions": "~1.0"
+        "fabpot/php-cs-fixer": "~1.12.0",
+        "phpunit/phpunit": "~4.8.0",
+        "jtreminio/test-extensions": "~1.0.0"
     },
     "minimum-stability": "dev",
     "config": {


### PR DESCRIPTION
Tasks done:
- [X] Do not mark game as over if it's a not forced draw. Claimable draws like repetition draws marked the game as over when the game is not really over.
- [X] Remove `$color` parameter for `inStalemate` . We always want to check based on the status of the board, the parameter was unused.
- [X] Remove unneded dependencies and bumped phpunit to the latest stable version.
