### PR TITLE
Fix invalid king moves

### DIFF
--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -985,4 +985,51 @@ class ChessGameTest extends TestExtensions
         $this->assertFalse($this->game->inForcedDraw());
         $this->assertFalse($this->game->gameOver());
     }
+
+    public function testKingValidMovesWithMoveSAN()
+    {
+        $this->game->resetGame();
+        $this->game->moveSAN('e4');
+        $this->game->moveSAN('e5');
+        $this->game->moveSAN('d4');
+        $this->game->moveSAN('exd4');
+        $this->game->moveSAN('Qxd4');
+        $this->game->moveSAN('Nc6');
+        $this->game->moveSAN('Qd1');
+        $this->game->moveSAN('Bd6');
+        $this->game->moveSAN('a3');
+        $this->game->moveSAN('Nf6');
+        $this->game->moveSAN('Nc3');
+        $this->game->moveSAN('Nxe4');
+        $this->game->moveSAN('Qe7');
+        $this->game->moveSAN('Qe2');
+        $this->assertTrue($this->game->isError($this->game->moveSAN('Kxe7')));
+    }
+
+    public function testKingValidMovesMakingMoves()
+    {
+        $this->game->resetGame();
+        $this->game->moveSquare('e2', 'e4');
+        $this->game->moveSquare('e7', 'e5');
+        $this->game->moveSquare('d2', 'd4');
+        $this->game->moveSquare('e5', 'd4');
+        $this->game->moveSquare('d1', 'd4');
+        $this->game->moveSquare('b8', 'c6');
+        $this->game->moveSquare('d4', 'd1');
+        $this->game->moveSquare('f8', 'd6');
+        $this->game->moveSquare('a2', 'a3');
+        $this->game->moveSquare('g8', 'f6');
+        $this->game->moveSquare('b1', 'c3');
+        $this->game->moveSquare('f6', 'e4');
+        $this->game->moveSquare('c3', 'e4');
+        $this->game->moveSquare('d8', 'e7');
+        $this->game->moveSquare('d1', 'e2');
+        $this->assertTrue($this->game->isError($this->game->moveSquare('e8', 'e7')));
+    }
+
+    public function testKingShouldNotTakeOwnPiece()
+    {
+        $this->game->resetGame('5b1r/1b2k1p1/2N1pn1p/BBP5/3P4/1PN1P3/1P3PPP/4K2R b K - 0 22');
+        $this->assertTrue($this->game->isError($this->game->moveSquare('e7', 'e6')));
+    }
 }

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -2445,22 +2445,42 @@ class ChessGame
                 array('square' => $from));
         }
 
-        if ($piece['piece'] == 'K') {
-            if ((($to == ($this->_QRookColumn . (($this->_move == 'B') ? '8' : '1'))) && $this->{'_' . $this->_move . 'CastleQ'}) || (($to == ($this->_KRookColumn . (($this->_move == 'B') ? '8' : '1'))) && $this->{'_' . $this->_move . 'CastleK'}) || !in_array($to, $this->getKingSquares($from))) {
-                // this is a castling attempt
-                if ($this->objColumnToNumber[$from{0}] < $this->objColumnToNumber[$to{0}]) {
+        $castleRow = ($this->_move == 'B')?'8':'1';
+        if ($piece['piece'] == 'K' && substr($to, 1, 1) == $castleRow) {
+            // the king can castle (if available) by trying to move to any non-adjacent
+            // square in that row OR the square with the target rook, WHICH MAY BE ADJACENT
+            // during a chess 960 game. We do not need to check if the target square is empty
+            // because once castling is declared very specific destinations are set and
+            // special validation rules are applied in _validMove.
+            // Worth pointing out: in chess 960, the queen may not actually be on a lower file
+            // than the king, but the notation remains the same. See _parseMove
+
+            $fromFile = substr($from, 0, 1);
+            if ($this->{'_' . $this->_move . 'CastleK'}) {
+                // list all files more than two away
+                $kingsideTargetFiles = array_slice(range($fromFile, 'h'), 2);
+                $kingsideTargetFiles[] = $this->_KRookColumn; // usually 'h'; chess960 may have it adjacent and excluded by the slice
+                if (in_array(substr($to, 0, 1), $kingsideTargetFiles)) {
                     return 'O-O';
-                } else {
+                }
+            }
+            if ($this->{'_' . $this->_move . 'CastleQ'}) {
+                // list all files more than two away
+                $queensideTargetFiles = array_slice(range($fromFile, 'a'), 2);
+                $queensideTargetFiles[] = $this->_QRookColumn; // usually 'a'; chess960 may have it adjacent and excluded by the slice
+                if (in_array(substr($to, 0, 1), $queensideTargetFiles)) {
                     return 'O-O-O';
                 }
             }
-        } else {
-            $moves = $this->getPossibleMoves($piece['piece'], $from, $piece['color']); //KK start: optimize: no need to get all possible moves
-            if (!in_array($to, $moves)) {
-                return $this->raiseError(self::GAMES_CHESS_ERROR_CANT_MOVE_THAT_WAY,
-                    array('from' => $from, 'to' => $to));
-            } //KK end
         }
+        // not an available castling move; continue checking as a normal move even for kings
+
+        $moves = $this->getPossibleMoves($piece['piece'], $from, $piece['color']);    //KK start: optimize: no need to get all possible moves
+        if (!in_array($to, $moves)) {
+            return $this->raiseError(self::GAMES_CHESS_ERROR_CANT_MOVE_THAT_WAY,
+                array('from' => $from, 'to' => $to));
+        }  //KK end
+
         $others = array();
         if ($piece['piece'] != 'K' && $piece['piece'] != 'P') {
             $others = $this->getAllPieceSquares($piece['piece'],


### PR DESCRIPTION
This is a combination of https://github.com/ChessCom/Chess-Game/pull/19 and https://github.com/ChessCom/Chess-Game/pull/16

Fixes the following bug:

When starting with the following FEN: `5b1r/1b2k1p1/2N1pn1p/BBP5/3P4/1PN1P3/1P3PPP/4K2R b K - 0 22`

The black king cannot take adjacent black pawn piece (move from e7 to e6)

I've added a new test that verifies that the bug is fixed with @BiviaBen 's changes.

cc: @jseverson 
