### PR TITLE
Fix PHP7 warnings

### DIFF
--- a/PEAR.php
+++ b/PEAR.php
@@ -167,7 +167,7 @@ class PEAR
      * @access public
      * @return void
      */
-    function PEAR($error_class = null)
+    function __construct($error_class = null)
     {
         $classname = strtolower(get_class($this));
         if ($this->_debug) {
@@ -854,7 +854,7 @@ class PEAR_Error
      * @access public
      *
      */
-    function PEAR_Error($message = 'unknown error', $code = null,
+    function __construct($message = 'unknown error', $code = null,
                         $mode = null, $options = null, $userinfo = null)
     {
         if ($mode === null) {


### PR DESCRIPTION
Fixed deprecation warnings like:

```
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; PEAR has a deprecated constructor in vendor/chesscom/chess-game/PEAR.php on line 102
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; PEAR_Error has a deprecated constructor in vendor/chesscom/chess-game/PEAR.php on line 822
```
