### PR TITLE
Add support to check if a player has mating material.

### DIFF
--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -1032,4 +1032,18 @@ class ChessGameTest extends TestExtensions
         $this->game->resetGame('5b1r/1b2k1p1/2N1pn1p/BBP5/3P4/1PN1P3/1P3PPP/4K2R b K - 0 22');
         $this->assertTrue($this->game->isError($this->game->moveSquare('e7', 'e6')));
     }
+
+    public function testHasMatingMaterialShouldReturnTrueOnStandardSetup()
+    {
+        $this->game->resetGame();
+        $this->assertTrue($this->game->hasBlackMatingMaterial());
+        $this->assertTrue($this->game->hasWhiteMatingMaterial());
+    }
+
+    public function testHasMatingMaterialShouldReturnTrueForBlackAndFalseForWhite()
+    {
+        $this->game->resetGame('8/8/8/8/5b2/8/4kpK1/8 b - - 1 86');
+        $this->assertFalse($this->game->hasWhiteMatingMaterial());
+        $this->assertTrue($this->game->hasBlackMatingMaterial());
+    }
 }

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -1490,6 +1490,57 @@ class ChessGame
         return false;
     }
 
+    /**
+     * @return bool
+     */
+    public function hasWhiteMatingMaterial()
+    {
+        return $this->hasMatingMaterial('W');
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasBlackMatingMaterial()
+    {
+        return $this->hasMatingMaterial('B');
+    }
+
+    /**
+     * @param string $color
+     *
+     * @return bool
+     */
+    private function hasMatingMaterial($color)
+    {
+        $pieces = $this->getPieceTypes();
+        $queens = isset($pieces[$color]['Q']) && is_array($pieces[$color]['Q']) ? count($pieces[$color]['Q']) : 0;
+        if ($queens > 0) {
+            return true;
+        }
+        $rooks = isset($pieces[$color]['R']) && is_array($pieces[$color]['R']) ? count($pieces[$color]['R']) : 0;
+        if ($rooks > 0) {
+            return true;
+        }
+        $pawns = isset($pieces[$color]['P']) && is_array($pieces[$color]['P']) ? count($pieces[$color]['P']) : 0;
+        if ($pawns > 0) {
+            return true;
+        }
+        $bishops = isset($pieces[$color]['B']) && is_array($pieces[$color]['B']) ? count($pieces[$color]['B']) : 0;
+        if ($bishops > 1) {
+            return true;
+        }
+        $knights = isset($pieces[$color]['N']) && is_array($pieces[$color]['N']) ? count($pieces[$color]['N']) : 0;
+        if ($knights > 2) {
+            return true;
+        }
+        if ($bishops === 1 && $knights > 0) {
+            return true;
+        }
+
+        return false;
+    }
+
     private function renderFenBit()
     {
         $fen = '';
@@ -3737,7 +3788,6 @@ class ChessGame
      *   'B' => array('Q' => array('B'), // all queens
      *                'K' => array('W'),... // king is on white square
      * </pre>
-     * @access protected
      */
     private function getPieceTypes()
     {


### PR DESCRIPTION
The following PR adds support to check if a player has mating material.

The method is needed to end a game in draw by insufficient material if the
player that wins on time does not have mating material.

Two developer facing methods were added:
- hasWhiteMatingMaterial and hasBlackMatingMaterial
