### PR TITLE
Fix 4 pieces not in basic draw

### DIFF
--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -575,6 +575,14 @@ class ChessGameTest extends TestCase
         $this->assertTrue($this->game->inBasicDraw());
     }
 
+    public function testIsNotInBasicDrawWith4pieces()
+    {
+        $startFen = '8/8/6B1/3k4/8/4K3/5Q2/8 w - -';
+
+        $this->game->resetGame($startFen);
+        $this->assertFalse($this->game->inBasicDraw());
+    }
+
     public function testIsInCheckmate()
     {
         $startFen = '3k2R1/8/3K4/8/8/8/8/8 b - -';

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -1453,6 +1453,8 @@ class ChessGame
                 && in_array($playerWith3Pieces[2], array('K', 'N'))) {
                 return true; //KNN vs K
             }
+
+            return false;
         }
 
         $playerWith2Pieces = count($whitePieces) === 2 ? $whitePieces : $blackPieces;


### PR DESCRIPTION
This PR https://github.com/ChessCom/Chess-Game/pull/36 introduced a bug for a specific 4 pieces endgame. 

Added fail test and fix:
![image (8)](https://user-images.githubusercontent.com/5374844/72726864-3df00880-3b68-11ea-9d27-26b7aea426cd.png)
