### PR TITLE
CV-142681 Chess-Game Do not allow pieces in rook position to castle

### DIFF
--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -71,6 +71,20 @@ class ChessGameTest extends TestCase
         $this->assertEquals('8/8/8/8/8/8/8/8 w KQkq - 1 1', $this->game->renderFen());
     }
 
+    public function testCastlingForbiddenIfNotRook()
+    {
+        $startFen = 'q3k2q/pbpqppbp/1pnp1np1/8/8/1PNP1NP1/PBPQPPBP/Q3K2Q w KQkq - 2 9';
+        $this->game->resetGame($startFen);
+
+        $this->assertFalse($this->game->canCastleKingside());
+        $this->assertFalse($this->game->canCastleQueenside());
+
+        $this->game->moveSAN('e3');
+
+        $this->assertFalse($this->game->canCastleKingside());
+        $this->assertFalse($this->game->canCastleQueenside());
+    }
+
     public function testCastlingBlackFromTheKingSide()
     {
         $startFen = 'rnbqk2r/pppp1ppp/5n2/2b1p3/P1P1P1P1/8/1P1P1P1P/RNBQKBNR b KQkq a3 0 4';

--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -76,13 +76,35 @@ class ChessGameTest extends TestCase
         $startFen = 'q3k2q/pbpqppbp/1pnp1np1/8/8/1PNP1NP1/PBPQPPBP/Q3K2Q w KQkq - 2 9';
         $this->game->resetGame($startFen);
 
-        $this->assertFalse($this->game->canCastleKingside());
-        $this->assertFalse($this->game->canCastleQueenside());
+        self::assertFalse($this->game->canCastleKingside());
+        self::assertFalse($this->game->canCastleQueenside());
 
         $this->game->moveSAN('e3');
 
-        $this->assertFalse($this->game->canCastleKingside());
-        $this->assertFalse($this->game->canCastleQueenside());
+        self::assertFalse($this->game->canCastleKingside());
+        self::assertFalse($this->game->canCastleQueenside());
+
+        $startFen = 'r3k2q/pppppppp/8/8/8/8/PPPPPPPP/Q3K2R w KQkq - 0 1';
+        $this->game->resetGame($startFen);
+
+        self::assertTrue($this->game->canCastleKingside());
+        self::assertFalse($this->game->canCastleQueenside());
+
+        $this->game->moveSAN('e3');
+
+        self::assertFalse($this->game->canCastleKingside());
+        self::assertTrue($this->game->canCastleQueenside());
+
+        $startFen = 'q3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2Q w KQkq - 0 1';
+        $this->game->resetGame($startFen);
+
+        self::assertFalse($this->game->canCastleKingside());
+        self::assertTrue($this->game->canCastleQueenside());
+
+        $this->game->moveSAN('e3');
+
+        self::assertTrue($this->game->canCastleKingside());
+        self::assertFalse($this->game->canCastleQueenside());
     }
 
     public function testCastlingBlackFromTheKingSide()

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -2200,16 +2200,16 @@ class ChessGame
                 }
                 switch ($splitFen[2][$i]) {
                     case 'K' :
-                        $this->_WCastleK = true;
+                        $this->_WCastleK = $this->getPiece('WR1') !== false;
                         break;
                     case 'Q' :
-                        $this->_WCastleQ = true;
+                        $this->_WCastleQ = $this->getPiece('WR2') !== false;
                         break;
                     case 'k' :
-                        $this->_BCastleK = true;
+                        $this->_BCastleK = $this->getPiece('BR1') !== false;
                         break;
                     case 'q' :
-                        $this->_BCastleQ = true;
+                        $this->_BCastleQ = $this->getPiece('BR2') !== false;
                         break;
                     default:
                         return $this->raiseError(self::GAMES_CHESS_ERROR_FEN_CASTLEWRONG,

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -2193,23 +2193,30 @@ class ChessGame
         $this->_WCastleK = false;
         $this->_BCastleQ = false;
         $this->_BCastleK = false;
+
+        $wr1 = $this->getPiece('WR1');
+        $wr2 = $this->getPiece('WR2');
+        $br1 = $this->getPiece('BR1');
+        $br2 = $this->getPiece('BR2');
+
         if ($splitFen[2] != '-') {
             for ($i = 0; $i < 4; $i++) {
                 if ($i >= strlen($splitFen[2])) {
                     continue;
                 }
+
                 switch ($splitFen[2][$i]) {
                     case 'K' :
-                        $this->_WCastleK = $this->getPiece('WR1') !== false;
+                        $this->_WCastleK = $wr1 === 'h1' || $wr2 === 'h1';
                         break;
                     case 'Q' :
-                        $this->_WCastleQ = $this->getPiece('WR2') !== false;
+                        $this->_WCastleQ = $wr1 === 'a1' || $wr2 === 'a1';
                         break;
                     case 'k' :
-                        $this->_BCastleK = $this->getPiece('BR1') !== false;
+                        $this->_BCastleK = $br1 === 'h8' || $br2 === 'h8';
                         break;
                     case 'q' :
-                        $this->_BCastleQ = $this->getPiece('BR2') !== false;
+                        $this->_BCastleQ = $br1 === 'a8' || $br2 === 'a8';
                         break;
                     default:
                         return $this->raiseError(self::GAMES_CHESS_ERROR_FEN_CASTLEWRONG,
@@ -3614,8 +3621,8 @@ class ChessGame
     public function isBishop($pieceName)
     {
         return $pieceName[1] == 'B' ||
-        ($pieceName[1] == 'P' &&
-            $this->_pieces[$pieceName][1] == 'B');
+            ($pieceName[1] == 'P' &&
+                $this->_pieces[$pieceName][1] == 'B');
     }
 
     /**
@@ -3631,8 +3638,8 @@ class ChessGame
     public function isRook($pieceName)
     {
         return $pieceName[1] == 'R' ||
-        ($pieceName[1] == 'P' &&
-            $this->_pieces[$pieceName][1] == 'R');
+            ($pieceName[1] == 'P' &&
+                $this->_pieces[$pieceName][1] == 'R');
     }
 
     /**
@@ -3648,7 +3655,7 @@ class ChessGame
     public function isPawn($pieceName)
     {
         return $pieceName[1] == 'P' &&
-        $this->_pieces[$pieceName][1] == 'P';
+            $this->_pieces[$pieceName][1] == 'P';
     }
 
     /**
@@ -3674,8 +3681,8 @@ class ChessGame
     public function _isKnight($pieceName)
     {
         return $pieceName[1] == 'N' ||
-        ($pieceName[1] == 'P' &&
-            $this->_pieces[$pieceName][1] == 'N');
+            ($pieceName[1] == 'P' &&
+                $this->_pieces[$pieceName][1] == 'N');
     }
 
     /**


### PR DESCRIPTION
In case of odds game or games with custom FEN such as `q3k2q/pbpqppbp/1pnp1np1/8/8/1PNP1NP1/PBPQPPBP/Q3K2Q w KQkq - 2 9` check that there are actually rooks in the board to decide if a king can castle or not.