### PR TITLE
Optionally use phpunit 9.5^ on PHP versions > 8

### DIFF
--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -9,7 +9,7 @@ class ChessGameTest extends TestCase
     /** @var ChessGame */
     private $game;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->game = new ChessGame();
     }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.3",
-        "phpunit/phpunit": "^7.3"
+        "phpunit/phpunit": "^7.3 || ^9.5"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
PHPUnit versions ^7.3 don't support PHP 8+ . Composer will optionally install PHPunit ^9.5 if the PHP version is 8+.