### PR TITLE
PHP8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - "7.2"
   - "7.3"
   - "7.4"
+  - "8.0"
 
 matrix:
   fast_finish: true

--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -1096,12 +1096,14 @@ class ChessGameTest extends TestCase
         $this->assertFiveFoldRepetitionDraw();
     }
 
-    /**
-     * PHP8
-     *
-     * E_WARNING: Undefined array key 2
-     */
-    public function testInBasicDrawWith3Pieces()
+    public function testNotInBasicDrawTwoWhiteVsTwoBlack()
+    {
+        $fen = '8/8/8/8/4k3/8/3Kn3/6Q1 w - -';
+        $this->game->resetGame($fen);
+        $this->assertFalse($this->game->inBasicDraw());
+    }
+
+    public function testInBasicDrawThreePiecesRemained()
     {
         $fen = '8/8/8/8/4k3/8/3K4/6n1 w - -';
         $this->game->resetGame($fen);

--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -9,7 +9,7 @@ class ChessGameTest extends TestCase
     /** @var ChessGame */
     private $game;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->game = new ChessGame();
     }
@@ -1094,6 +1094,18 @@ class ChessGameTest extends TestCase
             $this->game->moveSAN($move);
         }
         $this->assertFiveFoldRepetitionDraw();
+    }
+
+    /**
+     * PHP8
+     *
+     * E_WARNING: Undefined array key 2
+     */
+    public function testInBasicDrawWith3Pieces()
+    {
+        $fen = '8/8/8/8/4k3/8/3K4/6n1 w - -';
+        $this->game->resetGame($fen);
+        $this->assertTrue($this->game->inBasicDraw());
     }
 
     private function assertFiveFoldRepetitionDraw()

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
         }
     ],
     "require": {
-        "php": ">=8.0"
+        "php": ">=7.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.3",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^7.3 || ^9.5"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
         }
     ],
     "require": {
-        "php": ">=7.1"
+        "php": ">=8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.3",
-        "phpunit/phpunit": "^7.3"
+        "phpunit/phpunit": "^9.5"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -600,7 +600,7 @@ class ChessGame
 
                         if (count($legalMoves) != 1) {
                             $square = $col = $row = null;
-                            $pieces = implode($legalMoves, ' ');
+                            $pieces = implode(' ', $legalMoves);
 
                             return $this->raiseError(
                                 self::GAMES_CHESS_ERROR_TOO_AMBIGUOUS,
@@ -1448,9 +1448,11 @@ class ChessGame
 
             $playerWith3Pieces = count($whitePieces) === 3 ? $whitePieces : $blackPieces;
 
-            if (in_array($playerWith3Pieces[0], array('K', 'N'))
+            if (count($playerWith3Pieces) === 3
+                && in_array($playerWith3Pieces[0], array('K', 'N'))
                 && in_array($playerWith3Pieces[1], array('K', 'N'))
-                && in_array($playerWith3Pieces[2], array('K', 'N'))) {
+                && in_array($playerWith3Pieces[2], array('K', 'N'))
+            ) {
                 return true; //KNN vs K
             }
 


### PR DESCRIPTION
Supporting PHP8

- updating usage of [implode](https://www.php.net/manual/en/function.implode.php)
```
Legacy signature (deprecated as of PHP 7.4.0, removed as of PHP 8.0.0):

implode(array $array, string $separator): string
```

- fixing the case where 4 pieces are remained
```
$playerWith3Pieces = count($whitePieces) === 3 ? $whitePieces : $blackPieces;
```
This line was auto suggesting that in case of remained 4 pieces on board, in case that white doesn't have 3 pieces remained, that black has 3 pieces remained, while there are actual cases where it is 2 white vs 2 black pieces. 
This was giving a warning, since there wasn't 3 elements in the array, just two:
```
E_WARNING: Undefined array key 2
```

So far we have experienced these issues using Chess-Game library on PHP8, I hope there isn't any additional.