### PR TITLE
Handle Deprecated: Automatic conversion of false to array is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - "7.3"
   - "7.4"
   - "8.0"
+  - "8.1"
 
 matrix:
   fast_finish: true

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -1050,6 +1050,9 @@ class ChessGame
                                 $this->moveAlgebraic($this->_KRookColumn . $row, "f$row");
                             }
                             $this->_moveFromSquare = $this->_KColumn . $row;
+                            if (!is_array($this->_lastMove)) {
+                                $this->_lastMove = [];
+                            }
                             $this->_lastMove['square'] = "g$row";
                             break;
                         case 'Q' :
@@ -1065,6 +1068,9 @@ class ChessGame
                                 $this->moveAlgebraic($this->_QRookColumn . $row, "d$row");
                             }
                             $this->_moveFromSquare = $this->_KColumn . $row;
+                            if (!is_array($this->_lastMove)) {
+                                $this->_lastMove = [];
+                            }
                             $this->_lastMove['square'] = "c$row";
                             break;
                     }


### PR DESCRIPTION
After ChessKid production server upgrade this `Deprecated: Automatic conversion of false to array is deprecated` warning came up in Sentry. 
Autovivification on false is going to be deprecated, details about it can be found here https://wiki.php.net/rfc/autovivification_false 

`$_lastMove` property is initially set as `false` on very top of the class and the implemented fix just checks is the property an array, in case it is not, it sets/creates an array.