### PR TITLE
Support for php8.2, fix issue with dynamic property set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - "7.4"
   - "8.0"
   - "8.1"
+  - "8.2"
 
 matrix:
   fast_finish: true

--- a/PEAR.php
+++ b/PEAR.php
@@ -830,6 +830,7 @@ class PEAR_Error
     var $message              = '';
     var $userinfo             = '';
     var $backtrace            = null;
+    var $callback             = null;
 
     // }}}
     // {{{ constructor


### PR DESCRIPTION
Adding support for PHP8.2:
- updating `.travis.yml`
- adding missing property `$callback` in `class PEAR_Error`

The exact error which was shown was:
```
Deprecated: Creation of dynamic property PEAR_Error::$callback is deprecated in /vendor/chesscom/chess-game/PEAR.php on line 881
```