### PR TITLE
Support chess960 castle token parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 phpunit.xml
 bin
 phpunit-report
+.phpunit.result.cache

--- a/Tests/ChessGameTest.php
+++ b/Tests/ChessGameTest.php
@@ -833,18 +833,36 @@ class ChessGameTest extends TestCase
         $this->assertEquals('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1', $this->game->renderFen());
     }
 
-    // XXX: Parsing a legitimate Chess960 FEN appears to be horked
-    /**
-     * Set up a new Chess960 board. FEN generated at lichness.org
-     *
-     * @link http://en.lichess.org
-     */
-//    public function testNewChess960GameRenderedFen()
-//    {
-//        $fen = 'nrnbbkqr/pppppppp/8/8/8/8/PPPPPPPP/NRNBBKQR w KQkq - 0 1 ';
-//        $this->game->resetGame($fen, true);
-//        $this->assertEquals($fen, $this->game->renderFen());
-//    }
+   public function testChess960Castling()
+   {
+        $this->game->resetGame('nbbnqrkr/pppppppp/8/8/8/8/PPPPPPPP/NBBNQRKR w HFhf - 0 1', true);
+
+        $this->assertTrue($this->game->canCastleKingside());
+        $this->assertTrue($this->game->canCastleQueenside());
+
+        $this->game->resetGame('nrnbbkqr/pppppppp/8/8/8/8/PPPPPPPP/NRNBBKQR w kq - 0 1', true);
+
+        $this->assertFalse($this->game->canCastleKingside());
+        $this->assertFalse($this->game->canCastleQueenside());
+   }
+
+   public function testChess960GameRenderedFenOuterSquares()
+   {
+       $fen = 'nrnbbkqr/pppppppp/8/8/8/8/PPPPPPPP/NRNBBKQR w KQkq - 0 1';
+       $xFen = 'nrnbbkqr/pppppppp/8/8/8/8/PPPPPPPP/NRNBBKQR w KBkb - 0 1';
+
+       $this->game->resetGame($fen, true);
+
+       $this->assertNotEquals($fen, $this->game->renderFen());
+       $this->assertEquals($xFen, $this->game->renderFen());
+   }
+
+   public function testChess960GameRenderedFenInnerSquares()
+   {
+       $fen = '1rkbrq1n/pppp4/bn3pp1/4p2p/4P3/1N1P1PNB/PPP2QPP/1RK1R1B1 b EBeb - 1 8';
+       $this->game->resetGame($fen, true);
+       $this->assertEquals($fen, $this->game->renderFen());
+   }
 
     public function testNewStandardGameFen()
     {

--- a/src/Chess/Game/ChessGame.php
+++ b/src/Chess/Game/ChessGame.php
@@ -2219,6 +2219,27 @@ class ChessGame
                     case 'q' :
                         $this->_BCastleQ = true;
                         break;
+                    // 960 castling token - example: EBeb
+                    case strtoupper($this->_KRookColumn) :
+                        if ($this->_Chess960) {
+                            $this->_WCastleK = true;
+                            break;
+                        }
+                    case strtoupper($this->_QRookColumn) :
+                        if ($this->_Chess960) {
+                            $this->_WCastleQ = true;
+                            break;
+                        }
+                    case $this->_KRookColumn :
+                        if ($this->_Chess960) {
+                            $this->_BCastleK = true;
+                            break;
+                        }
+                    case $this->_QRookColumn :
+                        if ($this->_Chess960) {
+                            $this->_BCastleQ = true;
+                            break;
+                        }
                     default:
                         return $this->raiseError(self::GAMES_CHESS_ERROR_FEN_CASTLEWRONG,
                             array('fen' => $fen, 'castle' => $splitFen[2][$i]));


### PR DESCRIPTION
As far as I can tell we've never properly supported parsing the castling token for chess 960 fens when the rooks are not on the outer files 🤯 

Prior to this when calling `resetGame('1rkbrq1n/pppp4/bn3pp1/4p2p/4P3/1N1P1PNB/PPP2QPP/1RK1R1B1 b EBeb - 1 8', true)`, the board representation lacked castling rights for 960 games and rather than `EBeb` it was `-`.

Fix verified in chess repo https://github.com/ChessCom/chess/pull/112006